### PR TITLE
Switch to exjsx

### DIFF
--- a/lib/consul/agent/check.ex
+++ b/lib/consul/agent/check.ex
@@ -8,7 +8,7 @@ defmodule Consul.Agent.Check do
   use Consul.Endpoint, handler: Consul.Handler.Base
 
   def register(body) do
-    req_put("agent/check/register", JSEX.encode!(body))
+    req_put("agent/check/register", JSX.encode!(body))
   end
 
   def deregister(id) do

--- a/lib/consul/agent/service.ex
+++ b/lib/consul/agent/service.ex
@@ -8,7 +8,7 @@ defmodule Consul.Agent.Service do
   use Consul.Endpoint, handler: Consul.Handler.Base
 
   def register(%{"Name" => _} = body) do
-    req_put("agent/service/register", JSEX.encode!(body))
+    req_put("agent/service/register", JSX.encode!(body))
   end
 
   def deregister(id) do

--- a/lib/consul/catalog.ex
+++ b/lib/consul/catalog.ex
@@ -12,7 +12,7 @@ defmodule Consul.Catalog do
   end
 
   def deregister(%{"Datacenter" => _, "Node" => _} = body) do
-    req_put("catalog/deregister", JSEX.encode!(body))
+    req_put("catalog/deregister", JSX.encode!(body))
   end
 
   def nodes do

--- a/lib/consul/request.ex
+++ b/lib/consul/request.ex
@@ -19,7 +19,7 @@ defmodule Consul.Request do
   end
 
   def process_response_body(body) do
-    case JSEX.decode(body) do
+    case JSX.decode(body) do
       {:ok, decoded} ->
         decoded
       _ ->

--- a/mix.exs
+++ b/mix.exs
@@ -16,7 +16,7 @@ defmodule Consul.Mixfile do
     [
       applications: [
         :httpoison,
-        :jsex
+        :exjsx
       ],
       mod: {Consul, []},
       env: [
@@ -28,7 +28,7 @@ defmodule Consul.Mixfile do
 
   defp deps do
     [
-      {:jsex, "~> 2.0"},
+      {:exjsx, "~> 3.0"},
       {:httpoison, "~> 0.5.0"},
     ]
   end


### PR DESCRIPTION
I was getting the following error from consul-ex using it with discovery (both head from github).

Last message: :timeout
State: %{em: #PID<0.362.0>, index: nil, service: "downloader", services: [], task: nil}
*\* (exit) an exception was raised:
    *\* (FunctionClauseError) no function clause matching in JSEX.Decoder.format_key/2
        (jsex) lib/jsex.ex:101: JSEX.Decoder.format_key("Node", {:config, :binary, false})
        (jsex) lib/jsex.ex:97: JSEX.Decoder.handle_event/2
        (jsx) src/jsx_decoder.erl:163: :jsx_decoder.string/5
        (jsex) lib/jsex.ex:17: JSEX.decode!/2
        (jsex) lib/jsex.ex:24: JSEX.decode/2
        (consul) lib/consul/request.ex:22: Consul.Request.process_response_body/1
        (consul) lib/consul/request.ex:8: Consul.Request.response/3
        (consul) lib/consul/health.ex:8: Consul.Health.req_get/3

The JSON from Consul appears correct (it parses properly) so I looked to upgrade jsex but it appears to have morphed into exjsx. So this patch switches consul-ex over to exjsx. This removed the error for me immediately and I've had no issues using discovery with this in place.
