### PR TITLE
upgrade httpoison to ~> 0.7.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -29,7 +29,7 @@ defmodule Consul.Mixfile do
   defp deps do
     [
       {:exjsx, "~> 3.0"},
-      {:httpoison, "~> 0.6.0"},
+      {:httpoison, "~> 0.7.0"},
     ]
   end
 


### PR DESCRIPTION
Among other things this will allow us to specify the `:recv_timeout` option which will be useful for long poll requests.
