### PR TITLE
allow opts for httpoison on kv.fetch so long polling can be done with the recv_timeout option

### DIFF
--- a/lib/consul/kv.ex
+++ b/lib/consul/kv.ex
@@ -12,10 +12,10 @@ defmodule Consul.Kv do
   @kv "kv"
 
   @spec fetch(binary | [binary], Keyword.t) :: Endpoint.response
-  def fetch(key, opts \\ []) do
+  def fetch(key, opts \\ [], http_opts \\ []) do
     List.flatten([@kv, key])
       |> build_url(opts)
-      |> req_get()
+      |> req_get([], http_opts)
   end
 
   @spec fetch!(binary | [binary], Keyword.t) :: Response.t | no_return


### PR DESCRIPTION
I found that when trying to do a long poll for changes to a key, that hackney was timing me out. It turns out that (when combined with #6) you can pass through a `:recv_timeout` option you can increase the timeout necessary for the long polling operation.

I'm not sure this is the best way to expose httpoison options and if so, it should probably be added to all the request APIs instead of just kv fetch.

Thoughts?

_Before_

```
iex(1)> Consul.Kv.fetch("test/key", [consistent: "", index: 817, wait: "15s"])
{:error, %HTTPoison.Error{id: nil, reason: :timeout}}
```

_After_

```
iex(1)> Consul.Kv.fetch("test/key", [consistent: "", index: 817, wait: "15s"], [recv_timeout: 20_000])
{:ok,
 %HTTPoison.Response{body: [%{"CreateIndex" => 504, "Flags" => 0,
     "Key" => "test/key", "LockIndex" => 2, "ModifyIndex" => 817,
     "Session" => "c64d86ad-c3a8-a766-7479-eaf2b4e8d0b7", "Value" => "blah"}],
  headers: [{"Content-Type", "application/json"}, {"X-Consul-Index", "817"},
   {"X-Consul-Knownleader", "true"}, {"X-Consul-Lastcontact", "0"},
   {"Date", "Wed, 16 Sep 2015 06:48:39 GMT"}, {"Content-Length", "158"}],
  status_code: 200}}
```
