### PR TITLE
Update mix.exs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -29,7 +29,7 @@ defmodule Consul.Mixfile do
   defp deps do
     [
       {:exjsx, "~> 3.0"},
-      {:httpoison, "~> 0.6.0"},
+      {:httpoison, "~> 0.6"},
     ]
   end
 


### PR DESCRIPTION
Make it usable from more modern applications. `httpoison` is already `0.11`, so rely on it’s being semantically versioned.