### PR TITLE
Update to elixir 1.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,4 @@
 language: elixir
 sudo: false
+elixir:
+  - 1.4.4

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ An Elixir client for Consul's HTTP API
 
 ## Requirements
 
-* Elixir 1.0.0 or newer
+* Elixir 1.4.0 or newer
 
 ## Installation
 

--- a/lib/consul/handler/behaviour.ex
+++ b/lib/consul/handler/behaviour.ex
@@ -5,9 +5,8 @@
 #
 
 defmodule Consul.Handler.Behaviour do
-  use Behaviour
 
-  defcallback handle(result :: Consul.Response.t)
+  @callback handle(Consul.Response.t) :: Consule.Endpoint.response
 
   defmacro __using__(_) do
     quote do

--- a/lib/consul/handler/behaviour.ex
+++ b/lib/consul/handler/behaviour.ex
@@ -6,13 +6,13 @@
 
 defmodule Consul.Handler.Behaviour do
 
-  @callback handle(Consul.Response.t) :: Consule.Endpoint.response
+  @callback handle(Consul.Response.t) :: Consul.Endpoint.response
 
   defmacro __using__(_) do
     quote do
       @behaviour unquote(__MODULE__)
 
-      @spec handle(Consul.Response.t) :: Consule.Endpoint.response
+      @spec handle(Consul.Response.t) :: Consul.Endpoint.response
       def handle(%{status_code: 200} = response) do
         {:ok, response}
       end

--- a/lib/consul/request.ex
+++ b/lib/consul/request.ex
@@ -14,7 +14,7 @@ defmodule Consul.Request do
       <<"https://"::utf8, _::binary>> ->
         url
       _ ->
-        Path.join("http://#{host}:#{port}/v1", url)
+        Path.join("http://#{host()}:#{port()}/v1", url)
     end
   end
 

--- a/lib/consul/watch/event.ex
+++ b/lib/consul/watch/event.ex
@@ -39,7 +39,7 @@ defmodule Consul.Watch.Event do
   def handle_info(:timeout, %{name: name, index: index, em: em, l_time: l_time} = state) do
     case Event.list(wait: @wait, index: index) do
       {:ok, response} ->
-        events     = Event.from_response(response) |> Enum.filter &(&1.name == name)
+        events     = Event.from_response(response) |> Enum.filter(&(&1.name == name))
         new_l_time = Event.last_time(events)
         notify_events(events, em, index, l_time)
         {:noreply, %{state | index: consul_index(response), l_time: new_l_time}, 0}

--- a/lib/consul/watch/handler.ex
+++ b/lib/consul/watch/handler.ex
@@ -5,8 +5,6 @@
 #
 
 defmodule Consul.Watch.Handler do
-  use Behaviour
-
   @type on_return :: {:ok, term} | :remove_handler
 
   @doc """
@@ -15,7 +13,7 @@ defmodule Consul.Watch.Handler do
 
   See: http://www.consul.io/docs/agent/http.html#event
   """
-  defcallback handle_consul_events(events :: [Consul.Event.t], list) :: on_return
+  @callback handle_consul_events([Consul.Event.t], any) :: on_return
 
   defmacro __using__(_) do
     quote do

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Consul.Mixfile do
     [
       app: :consul,
       version: "1.1.0",
-      elixir: "~> 1.4",
+      elixir: "~> 1.4.4",
       deps: deps(),
       package: package(),
       description: description()

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Consul.Mixfile do
     [
       app: :consul,
       version: "1.1.0",
-      elixir: "~> 1.0",
+      elixir: "~> 1.4",
       deps: deps(),
       package: package(),
       description: description()


### PR DESCRIPTION
### Description

A colleague of mine and I were looking at this library. We were thinking about using it for some internal tooling. 
However, we are running elixir 1.4. I thought it would be best to update the version of elixir used to compile this project, as the version was a bit old.

### What did I do

Bump the elixir version to 1.4 and remove deprecation warning while compiling.
This involved removing some ambiguous pipes, and usages of the `Behaviour` module

### Risks
 * Low: Not bumping a major version, but a minor version. App still compiles
